### PR TITLE
Fix triton example in readme

### DIFF
--- a/replit-code-v1-3b/README.md
+++ b/replit-code-v1-3b/README.md
@@ -106,7 +106,7 @@ model.to(device='cuda:0', dtype=torch.bfloat16)
 
 # forward pass
 x = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
-x = x.to(device='cuda:0', dtype=torch.bfloat16)
+x = x.to(device='cuda:0')
 y = model(x)
 
 ```


### PR DESCRIPTION
The input token IDs should be `long`, not `bfloat16`, when using the Triton attention implementation, as they're fed to an embedding layer.