### PR TITLE
Update modeling_mpt.py

### DIFF
--- a/replit-code-v1-3b/modeling_mpt.py
+++ b/replit-code-v1-3b/modeling_mpt.py
@@ -23,6 +23,7 @@ Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 class MPTPreTrainedModel(PreTrainedModel):
     config_class = MPTConfig
     base_model_prefix = 'model'
+    _no_split_modules=["MPTBlock"]
 
 class MPTModel(MPTPreTrainedModel):
 


### PR DESCRIPTION
Why
===

We had an open source PR on the HF repo that enables 8-bit and 4-bit quantization:
https://huggingface.co/replit/replit-code-v1-3b/discussions/19/files

What changed
============

Replicated those PR's changes here.

Testing
=========

Tested that loading in  8-bit and 4-bit quantization work.

Rollout
=======

- [x] This is fully backward and forward compatible 


